### PR TITLE
Fix CmakeLists for Catkin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,8 @@ project(tdbow)
 ## Option setting ##
 ####################
 
-option(BUILD_TDBOW_PC_Demo "Build PC demo" ON)
-option(BUILD_TDBOW_CV_Demo "Build CV demo" ON)
+option(BUILD_TDBOW_PC_Demo "Build PC demo" OFF)
+option(BUILD_TDBOW_CV_Demo "Build CV demo" OFF)
 option(ABSOLUTE_LOG    "Log absolute path" ON)
 
 if(NOT ABSOLUTE_LOG)
@@ -41,7 +41,7 @@ SET(CMAKE_CXX_FLAGS "-O3 ${CMAKE_CXX_FLAGS}")
 ###################
 ## find packages ##
 ###################
-find_package(catkin REQUIRED)
+find_package(catkin QUIET)
 
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
 
@@ -49,16 +49,16 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODUL
 
 # Manually resolve removed dependend packages
 find_package(Eigen3 QUIET)
-if (NOT EIGEN3_FOUND)
+if(NOT EIGEN3_FOUND)
   # Fallback to cmake_modules
   find_package(cmake_modules REQUIRED)
   find_package(Eigen REQUIRED)
   set(EIGEN3_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS})
   set(EIGEN3_LIBRARIES ${EIGEN_LIBRARIES})  # Not strictly necessary as Eigen is head only
   # Possibly map additional variables to the EIGEN3_ prefix.
-else ()
+else()
   set(EIGEN3_INCLUDE_DIRS ${EIGEN3_INCLUDE_DIR})
-endif ()
+endif()
 
 find_package(Boost REQUIRED COMPONENTS filesystem)
 if(NOT (Boost_VERSION VERSION_LESS "106000"))
@@ -101,9 +101,11 @@ catkin_package(
     LIBRARIES ${PROJECT_NAME}
 )
 
-link_libraries(
-    ${catkin_LIBRARIES}
-)
+if(catkin_FOUND)
+  link_libraries(
+      ${catkin_LIBRARIES}
+  )
+endif()
 
 ## Setting TDBoW context
 set(TDBoW_INC include/TDBoW)
@@ -158,10 +160,12 @@ endif()
 #############
 # Install all targets, headers by default and scripts and other files if specified (folders or files)
 
-install(TARGETS ${PROJECT_NAME}
-        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-        RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
+if(catkin_FOUND)
+  install(TARGETS ${PROJECT_NAME}
+          ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+          LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+          RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION})
 
-install(FILES ${TDBoW_HDRS} ${QUICKLZ_HDR}
-        DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+  install(FILES ${TDBoW_HDRS} ${QUICKLZ_HDR}
+          DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,12 @@ set(EXTRA_LIBS yaml-cpp ${EXTRA_LIBS})
 ###################################
 ## catkin specific configuration ##
 ###################################
-catkin_package(
-    INCLUDE_DIRS include libs/quicklz
-    LIBRARIES ${PROJECT_NAME}
-)
-
 if(catkin_FOUND)
+  catkin_package(
+      INCLUDE_DIRS include libs/quicklz
+      LIBRARIES ${PROJECT_NAME}
+  )
+
   link_libraries(
       ${catkin_LIBRARIES}
   )

--- a/README.md
+++ b/README.md
@@ -26,11 +26,57 @@ The main differences with the previous DBow2 library are:
   compile version less than c++11.
   * Stop words won't lose IDF information any more.
 
-TDBoW requires Eigen, yaml-cpp and Boost-filesystem.
-
-(Still work-in-progress) TDBoW, along with DLoopDetector, has been tested on several real datasets,
+(Still work-in-progress) TDBoW, along with TDLoopDetector, has been tested on several real datasets,
 yielding an execution time of 3 ms to convert the BRIEF features of an image into a bag-of-words vector
 and 5 ms to look for image matches in a database with more than 19000 images.
+
+## Getting Started
+
+TDBoW requires Eigen, FLANN, yaml-cpp and Boost-filesystem.
+
+### Prerequisites
+
+This is only valid in Debian Systems, other platform should manually install these tools.
+Note that all the prerequisites are included in ROS-desktop-full, so ROS users can skip this.
+
+TDBoW use CMake to compile
+
+```bash
+sudo apt install build-essential cmake
+```
+
+Several thirdparty libraries are required
+
+```bash
+sudo apt install libboost-filesystem-dev libflann-dev libyaml-cpp-dev libeigen3-dev
+```
+
+(Optional) TDBoW can be used as a catkin package, so catkin is also supported
+
+```bash
+sudo apt install catkin
+sudo apt install python-catkin-tools    # (Optional) Require ROS apt source
+```
+
+(Optional) We implement the TDBoW in both PC (3D) and CV (2D) mode, so the features extraction libraries is up to your application, [PCL](https://github.com/PointCloudLibrary/pcl) and [OpenCV](https://github.com/opencv/opencv) is recommended.
+
+### Installing
+
+Using CMake
+
+```bash
+git clone https://github.com/smallchimney/TDBoW.git
+mkdir TDBoW/build && cd TDBoW/build
+cmake ..
+make -j
+```
+
+Using Catkin, catkin workspace is required
+
+```bash
+git clone https://github.com/smallchimney/TDBoW.git
+catkin build  # Or you can use native catkin_make
+```
 
 ## Citing
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt install libboost-filesystem-dev libflann-dev libyaml-cpp-dev libeigen3-
 (Optional) TDBoW can be used as a catkin package, so catkin is also supported
 
 ```bash
-sudo apt install catkin
+sudo apt install catkin python-nose
 sudo apt install python-catkin-tools    # (Optional) Require ROS apt source
 ```
 


### PR DESCRIPTION
* Turn off the examples compile in default
* Make Catkin optional
* Update README, add install guide